### PR TITLE
Set the modified $defaults array as the bundle defaults

### DIFF
--- a/DependencyInjection/NelmioCorsExtension.php
+++ b/DependencyInjection/NelmioCorsExtension.php
@@ -58,7 +58,7 @@ class NelmioCorsExtension extends Extension
             $config['paths'][$path] = $opts;
         }
 
-        $container->setParameter('nelmio_cors.defaults', $config['defaults']);
+        $container->setParameter('nelmio_cors.defaults', $defaults);
         $container->setParameter('nelmio_cors.map', $config['paths']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));


### PR DESCRIPTION
[Line 50](https://github.com/leevigraham/NelmioCorsBundle/blob/51403cbe34aafb41577753d1a9a80b3168f0b6bd/DependencyInjection/NelmioCorsExtension.php#L50) modifies the $defaults array but [Line 61](https://github.com/leevigraham/NelmioCorsBundle/blob/51403cbe34aafb41577753d1a9a80b3168f0b6bd/DependencyInjection/NelmioCorsExtension.php#L61) sets the unmodified array.

This generally isn't a problem until paths is an empty array and the defaults are merged in:

``` Yaml
nelmio_cors:
    defaults:
        allow_credentials: true
        allow_origin: ['*']
        allow_headers: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept']
        allow_methods: ['POST','GET','DELETE','PUT','PATCH']
        expose_headers: ['*']
        max_age: 0
    paths:
      '^/': ~
```
