### PR TITLE
Check if Origin is the same as request Hostname

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -56,7 +56,7 @@ class CorsListener
         $request = $event->getRequest();
 
         // skip if not a CORS request
-        if (!$request->headers->has('Origin')) {
+        if (!$request->headers->has('Origin') || $request->headers->get('Origin') == $request->getSchemeAndHttpHost()) {
             return;
         }
 

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -92,4 +92,26 @@ class CorsListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $resp->headers->get('Access-Control-Allow-Methods'));
         $this->assertEquals(null, $resp->headers->get('Access-Control-Allow-Headers'));
     }
+
+    public function testSameHostRequest()
+    {
+        // Request with same host as origin
+        $config = array('/foo' => array(
+            'allow_origin' => array(),
+            'allow_headers' => array('foo', 'bar'),
+            'allow_methods' => array('POST', 'PUT'),
+        ));
+
+        $req = Request::create('/foo', 'POST');
+        $req->headers->set('Host', 'example.com');
+        $req->headers->set('Origin', 'http://example.com');
+
+        $callback = null;
+        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $this->getListener($config, array(), $dispatcher)->onKernelRequest($event);
+
+        $this->assertNull($event->getResponse());
+    }
 }


### PR DESCRIPTION
I've added a check that doesn't treat the request as Cors if the Origin header is the same as the requested Host. This can happen on form submits that sends both the referal and the Origin header even if it's just a redirect within the same host.
