### PR TITLE
Added abstract CORS configuration

### DIFF
--- a/DependencyInjection/Compiler/CorsConfigurationProviderPass.php
+++ b/DependencyInjection/Compiler/CorsConfigurationProviderPass.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass for the nelmio_cors.configuration.provider tag.
+ */
+class CorsConfigurationProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('nelmio_cors.options_resolver')) {
+            return;
+        }
+
+        $resolverDefinition = $container->getDefinition('nelmio_cors.options_resolver');
+
+        $optionsProvidersByPriority = array();
+        foreach ($container->findTaggedServiceIds('nelmio_cors.options_provider') as $taggedServiceId => $tagAttributes) {
+            foreach ($tagAttributes as $attribute) {
+                $priority = isset($attribute['priority']) ? $attribute['priority'] : 0;
+                $optionsProvidersByPriority[$priority][] = new Reference($taggedServiceId);
+            }
+        }
+
+        if (count($optionsProvidersByPriority) > 0) {
+            $resolverDefinition->setArguments(
+                array($this->sortProviders($optionsProvidersByPriority))
+            );
+        }
+    }
+
+    /**
+     * Transforms a two-dimensions array of providers, indexed by priority, into a flat array of Reference objects
+     * @param array $providersByPriority
+     * @return Reference[]
+     */
+    protected function sortProviders(array $providersByPriority)
+    {
+        ksort($providersByPriority);
+        return call_user_func_array('array_merge', $providersByPriority);
+    }
+}

--- a/NelmioCorsBundle.php
+++ b/NelmioCorsBundle.php
@@ -12,10 +12,16 @@
 namespace Nelmio\CorsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 class NelmioCorsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new DependencyInjection\Compiler\CorsConfigurationProviderPass());
+    }
 }

--- a/Options/ConfigProvider.php
+++ b/Options/ConfigProvider.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Options;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Default CORS configuration provider.
+ *
+ * Uses the bundle's semantic configuration.
+ * Default settings are the lowest priority one, and can be relied upon.
+ */
+class ConfigProvider implements ProviderInterface
+{
+    protected $paths;
+    protected $defaults;
+
+    public function __construct(array $paths, array $defaults = array())
+    {
+        $this->defaults = $defaults;
+        $this->paths = $paths;
+    }
+
+    public function getOptions(Request $request)
+    {
+        $uri = $request->getPathInfo() ?: '/';
+        foreach ($this->paths as $pathRegexp => $options) {
+            if (preg_match('{'.$pathRegexp.'}i', $uri)) {
+                return array_merge($this->defaults, $options);
+            }
+        }
+        return $this->defaults;
+    }
+}

--- a/Options/ProviderInterface.php
+++ b/Options/ProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Options;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CORS configuration provider interface.
+ *
+ * Can override CORS options for a particular path.
+ */
+interface ProviderInterface
+{
+    /**
+     * Returns CORS options for $request.
+     *
+     * Any valid CORS option will overwrite those of the previous ones.
+     * The method must at least return an empty array.
+     *
+     * All keys of the bundle's semantical configuration are valid:
+     * - bool allow_credentials
+     * - bool allow_origin
+     * - bool allow_headers
+     * - array allow_methods
+     * - array expose_headers
+     * - int max_age
+     *
+     * @param Request $request
+     *
+     * @return array CORS options
+     */
+    public function getOptions(Request $request);
+}

--- a/Options/Resolver.php
+++ b/Options/Resolver.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Options;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CORS options resolver.
+ *
+ * Uses Cors providers to resolve options for an HTTP request
+ */
+class Resolver implements ResolverInterface
+{
+    /**
+     * CORS configuration providers, indexed by numerical priority
+     * @var ProviderInterface[][]
+     */
+    private $providers;
+
+    /**
+     * @param $providers ProviderInterface[]
+     */
+    public function __construct(array $providers = array())
+    {
+        $this->providers = $providers;
+    }
+
+    /**
+     * Resolves the options for $request based on {@see $providers} data
+     *
+     * @param Request $request
+     *
+     * @return array CORS options
+     */
+    public function getOptions(Request $request)
+    {
+        $options = array();
+        foreach ($this->providers as $provider) {
+            $options = array_merge($options, $provider->getOptions($request));
+        }
+
+        return $options;
+    }
+}

--- a/Options/ResolverInterface.php
+++ b/Options/ResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Options;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ResolverInterface
+{
+    /**
+     * Returns CORS options for $path
+     *
+     * @param Request $request
+     *
+     * @internal param string $path
+     *
+     * @return mixed
+     */
+    public function getOptions(Request $request);
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,14 +6,21 @@
 
     <parameters>
         <parameter key="nelmio_cors.cors_listener.class">Nelmio\CorsBundle\EventListener\CorsListener</parameter>
+        <parameter key="nelmio_cors.options_resolver.class">Nelmio\CorsBundle\Options\Resolver</parameter>
+        <parameter key="nelmio_cors.options_provider.config.class">Nelmio\CorsBundle\Options\ConfigProvider</parameter>
     </parameters>
 
     <services>
         <service id="nelmio_cors.cors_listener" class="%nelmio_cors.cors_listener.class%">
             <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="nelmio_cors.options_resolver" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10000" />
+        </service>
+        <service id="nelmio_cors.options_resolver" class="%nelmio_cors.options_resolver.class%" public="false" />
+        <service id="nelmio_cors.options_provider.config" class="%nelmio_cors.options_provider.config.class%">
             <argument>%nelmio_cors.map%</argument>
             <argument>%nelmio_cors.defaults%</argument>
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10000" />
+            <tag name="nelmio_cors.options_provider" priority="-1" />
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
+++ b/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * File containing the CorsConfigurationProviderPassTest class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace Nelmio\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTest;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Nelmio\CorsBundle\DependencyInjection\Compiler\CorsConfigurationProviderPass;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CorsConfigurationProviderPassTest extends AbstractCompilerPassTest
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CorsConfigurationProviderPass());
+    }
+
+    public function testCollectProviders()
+    {
+        $configurationResolver = new Definition();
+        $this->setDefinition('nelmio_cors.options_resolver', $configurationResolver);
+
+        $configurationProvider = new Definition();
+        $configurationProvider->addTag('nelmio_cors.options_provider');
+        $this->setDefinition('cors.options_provider.test1', $configurationProvider);
+
+        $configurationProvider = new Definition();
+        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 10));
+        $this->setDefinition('cors.options_provider.test2', $configurationProvider);
+
+        $configurationProvider = new Definition();
+        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 5));
+        $this->setDefinition('cors.options_provider.test3', $configurationProvider);
+
+        $configurationProvider = new Definition();
+        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 5));
+        $this->setDefinition('cors.options_provider.test4', $configurationProvider);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'nelmio_cors.options_resolver',
+            0,
+            array(
+                new Reference('cors.options_provider.test1'),
+                new Reference('cors.options_provider.test3'),
+                new Reference('cors.options_provider.test4'),
+                new Reference('cors.options_provider.test2')
+            )
+        );
+    }
+}

--- a/Tests/Options/ConfigProviderTest.php
+++ b/Tests/Options/ConfigProviderTest.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Tests\Options;
+
+use Nelmio\CorsBundle\Options\ConfigProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+class ConfigProviderTest extends \PHPUnit_Framework_TestCase
+{
+    protected $defaultOptions = array(
+        'allow_credentials' => false,
+        'allow_origin' => array( 'http://one.example.com' ),
+        'allow_headers' => false,
+        'allow_methods' => array( 'GET' ),
+        'expose_headers' => array(),
+        'max_age' => 0
+    );
+
+    protected $pathOptions = array(
+        'allow_credentials' => true,
+        'allow_origin' => array( 'http://two.example.com' ),
+        'allow_headers' => true,
+        'allow_methods' => array( 'PUT', 'POST' ),
+        'expose_headers' => array( 'X-CorsTest' ),
+        'max_age' => 120
+    );
+
+    public function testGetOptionsForPathDefault()
+    {
+        $provider = $this->getProvider();
+
+        self::assertEquals(
+            $this->defaultOptions,
+            $provider->getOptions(Request::create('/default/path'))
+        );
+    }
+
+    public function testGetOptionsForMappedPath()
+    {
+        $provider = $this->getProvider();
+
+        self::assertEquals(
+            $this->pathOptions,
+            $provider->getOptions(Request::create('/test/abc'))
+        );
+    }
+
+    /**
+     * @return ConfigProvider
+     */
+    protected function getProvider()
+    {
+        return new ConfigProvider(
+            array(
+                '^/test/' => $this->pathOptions,
+                '^/othertest/' => array(
+                    'allow_credentials' => true,
+                    'allow_origin' => array( 'http://nope.example.com' ),
+                    'allow_headers' => true,
+                    'allow_methods' => array( 'COPY' ),
+                    'expose_headers' => array( 'X-Cors-Nope' ),
+                    'max_age' => 42
+                )
+            ),
+            $this->defaultOptions
+        );
+    }
+}

--- a/Tests/Options/ResolverTest.php
+++ b/Tests/Options/ResolverTest.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * This file is part of the NelmioCorsBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Nelmio\CorsBundle\Tests\Options;
+
+use Nelmio\CorsBundle\Options\ProviderInterface;
+use Nelmio\CorsBundle\Options\Resolver;
+use Mockery as m;
+use Symfony\Component\HttpFoundation\Request;
+
+class ResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Resolver */
+    protected $resolver;
+
+    /** @var ProviderInterface */
+    protected $defaultProviderMock;
+
+    /** @var ProviderInterface */
+    protected $extraProviderMock;
+
+    /**
+     * Return value of the default (low priority) provider
+     * @var array
+     */
+    protected $defaultProviderValue;
+
+    /**
+     * Return value of the extra (high priority) provider
+     * @var array
+     */
+    protected $extraProviderValue;
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testGetOptionsForPath()
+    {
+        $this->defaultProviderValue = array(
+            'simple_value' => 'a',
+            'other_simple_value' => 'b',
+            'array_value' => array( 'a', 'b' ),
+            'other_array_value' => array( 'c', 'd' ),
+        );
+
+        $this->extraProviderValue = array(
+            'simple_value' => 'c',
+            'array_value' => array( 'e' ),
+            'new_value' => 'x'
+        );
+
+        self::assertEquals(
+            array(
+                'simple_value' => 'c',
+                'other_simple_value' => 'b',
+                'array_value' => array( 'e' ),
+                'other_array_value' => array( 'c', 'd' ),
+                'new_value' => 'x'
+            ),
+            $this->getResolver()->getOptions(new Request)
+        );
+    }
+
+    /**
+     * @return Resolver
+     */
+    protected function getResolver()
+    {
+        return new Resolver(
+            array(
+                $this->getDefaultProviderMock(),
+                $this->getExtraProviderMock()
+            )
+        );
+    }
+
+    /**
+     * @return m\MockInterface|ProviderInterface
+     */
+    protected function getDefaultProviderMock()
+    {
+        $mock = $this->getProviderMock();
+        $mock
+            ->shouldReceive('getOptions')
+            ->once()
+            ->andReturn($this->defaultProviderValue);
+
+        return $mock;
+    }
+
+    /**
+     * @return m\MockInterface|ProviderInterface
+     */
+    protected function getExtraProviderMock()
+    {
+        $mock = $this->getProviderMock();
+        $mock
+            ->shouldReceive('getOptions')
+            ->once()
+            ->andReturn($this->extraProviderValue);
+
+        return $mock;
+    }
+
+    /**
+     * @return m\MockInterface|ProviderInterface
+     */
+    protected function getProviderMock()
+    {
+        return m::mock('Nelmio\CorsBundle\Options\ProviderInterface');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master"
+        "mockery/mockery": "dev-master",
+        "matthiasnoback/symfony-dependency-injection-test": "0.2.*"
     },
     "autoload": {
         "psr-0": { "Nelmio\\CorsBundle": "" }


### PR DESCRIPTION
This pull request makes the CORS configuration abstract and extensible.
## Detailled description

Configuration providers can be implemented based on `Options\ProviderInterface`, and registered as such using the `nelmio_cors.options_provider` service tag:

``` yaml
services:
    my.cors_options_provider:
        class: My\CorsOptionsProvider
        tags:
            - { name: nelmio_cors.options_provider }
```

The tag has an optional 'priority' attribute that defaults to 0.

Providers will, through the `getOptions()` interface method, return CORS options based on an HTTP Request. The hash may contain any of the cors options keys, as defined in the bundle's documentation (`allow_methods`, `allow_headers`...).
## Backward compatibility

The existing, semantic, CORS configuration is implemented in a `Options\ConfigProvider`. It has a priority of -1, and is registered by default.

Without any custom provider, the behavior is unchanged.
## Real-life example

ezsystems/ezpublish-kernel#663 uses a custom provider that matches the requested path against the router, and returns the registered REST routes.

It provides `allow_methods` and `expose_headers` options. All other options use the default semantic config, as can be seen in ezsystems/ezpublish-community#89.
## Testing

All submitted code should have a coverage of about 100%, and is used in the pull-requests linked above.
