### PR TITLE
Do not transform method-names, they're case-sensitive

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -111,7 +111,7 @@ class CorsListener
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }
         if ($options['allow_methods']) {
-            $response->headers->set('Access-Control-Allow-Methods', strtoupper(implode(', ', $options['allow_methods'])));
+            $response->headers->set('Access-Control-Allow-Methods', implode(', ', $options['allow_methods']));
         }
         if ($options['allow_headers']) {
             $headers = $options['allow_headers'] === true
@@ -132,10 +132,20 @@ class CorsListener
         $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
         // check request method
-        if (!in_array($request->headers->get('Access-Control-Request-Method'), $options['allow_methods'], true)) {
+        if (!in_array(strtoupper($request->headers->get('Access-Control-Request-Method')), $options['allow_methods'], true)) {
             $response->setStatusCode(405);
 
             return $response;
+        }
+
+        /**
+         * We have to allow the header in the case-set as we received it by the client.
+         * Firefox f.e. sends the LINK method as "Link", and we have to allow it like this or the browser will deny the
+         * request.
+         */
+        if (!in_array($request->headers->get('Access-Control-Request-Method'), $options['allow_methods'], true)) {
+            $options['allow_methods'][] = $request->headers->get('Access-Control-Request-Method');
+            $response->headers->set('Access-Control-Allow-Methods', implode(', ', $options['allow_methods']));
         }
 
         // check request headers


### PR DESCRIPTION
...uppercased list of allowed methods

Fixes #19

Works around a known bug in Firefox. See http://stackoverflow.com/questions/9649972/firefox-overwrites-custom-http-method-link-to-mixed-case-link-on-xhr
