### PR TITLE
Disable the normalization of keys for paths

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ class Configuration implements ConfigurationInterface
 
                 ->arrayNode('paths')
                     ->useAttributeAsKey('path')
+                    ->normalizeKeys(false)
                     ->prototype('array')
                         ->append($this->getAllowCredentials())
                         ->append($this->getAllowOrigin())

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ allowed methods however have to be explicitly listed. `paths` must contain at le
 > enabled in the framework, it will enable the API users to perform PUT and DELETE 
 > requests as well.
 
-## Installation (Symfony 2.1+)
+## Installation (Symfony 2.2+)
 
 Require the `nelmio/cors-bundle` package in your composer.json and update your dependencies.
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.1"
+        "symfony/framework-bundle": "~2.2"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",


### PR DESCRIPTION
The normalization transform dashes to underscores in the paths' keys so the paths that use dashes are not detected.

But we need to upgrade Symfony for Composer because the use of the method `normalizeKeys()` from the class `ArrayNodeDefinition` was introduced in Symfony 2.2.

This fixes #26.
