### PR TITLE
Add content-type as header always accepted

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -34,6 +34,7 @@ class CorsListener
         'accept-language',
         'content-language',
         'origin',
+        'content-type',
     );
 
     protected $dispatcher;


### PR DESCRIPTION
Content-Type header is the MIME type of the body of the request (used with POST and PUT requests). It is a common header so this should fix a lot of issues.
