### PR TITLE
Add an option to force Access-Control-Allow-Origin value

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
                     ->append($this->getMaxAge())
                     ->append($this->getHosts())
                     ->append($this->getOriginRegex())
+                    ->append($this->getForcedAllowOriginValue())
                 ->end()
 
                 ->arrayNode('paths')
@@ -56,6 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getMaxAge())
                         ->append($this->getHosts())
                         ->append($this->getOriginRegex())
+                        ->append($this->getForcedAllowOriginValue())
                     ->end()
                 ->end()
             ;
@@ -158,6 +160,14 @@ class Configuration implements ConfigurationInterface
     {
         $node = new BooleanNodeDefinition('origin_regex');
         $node->defaultFalse();
+
+        return $node;
+    }
+
+    private function getForcedAllowOriginValue()
+    {
+        $node = new ScalarNodeDefinition('forced_allow_origin_value');
+        $node->defaultNull();
 
         return $node;
     }

--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -91,7 +91,11 @@ class CorsListener
         $response = $event->getResponse();
         $request = $event->getRequest();
         // add CORS response headers
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        $response->headers->set('Access-Control-Allow-Origin',
+            !empty($this->options['forced_allow_origin_value'])
+                ? $this->options['forced_allow_origin_value']
+                : $request->headers->get('Origin')
+        );
         if ($this->options['allow_credentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }
@@ -126,7 +130,11 @@ class CorsListener
             return $response;
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        $response->headers->set('Access-Control-Allow-Origin',
+            !empty($options['forced_allow_origin_value'])
+                ? $options['forced_allow_origin_value']
+                : $request->headers->get('Origin')
+        );
 
         // check request method
         if (!in_array(strtoupper($request->headers->get('Access-Control-Request-Method')), $options['allow_methods'], true)) {

--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -37,7 +37,6 @@ class CorsListener
     );
 
     protected $dispatcher;
-    protected $options;
 
     /** @var ResolverInterface */
     protected $configurationResolver;
@@ -61,9 +60,7 @@ class CorsListener
             return;
         }
 
-        $options = $this->configurationResolver->getOptions($request);
-
-        if (!$options) {
+        if (!$options = $this->configurationResolver->getOptions($request)) {
             return;
         }
 
@@ -79,7 +76,6 @@ class CorsListener
         }
 
         $this->dispatcher->addListener('kernel.response', array($this, 'onKernelResponse'));
-        $this->options = $options;
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -88,19 +84,22 @@ class CorsListener
             return;
         }
 
+        if (!$options = $this->configurationResolver->getOptions($request = $event->getRequest())) {
+            return;
+        }
+
         $response = $event->getResponse();
-        $request = $event->getRequest();
         // add CORS response headers
         $response->headers->set('Access-Control-Allow-Origin',
-            !empty($this->options['forced_allow_origin_value'])
-                ? $this->options['forced_allow_origin_value']
+            !empty($options['forced_allow_origin_value'])
+                ? $options['forced_allow_origin_value']
                 : $request->headers->get('Origin')
         );
-        if ($this->options['allow_credentials']) {
+        if ($options['allow_credentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }
-        if ($this->options['expose_headers']) {
-            $response->headers->set('Access-Control-Expose-Headers', strtolower(implode(', ', $this->options['expose_headers'])));
+        if ($options['expose_headers']) {
+            $response->headers->set('Access-Control-Expose-Headers', strtolower(implode(', ', $options['expose_headers'])));
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the NelmioCorsBundle to your application's kernel:
         );
         // ...
     }
-````
+```
 
 ## Configuration
 
@@ -56,6 +56,7 @@ seconds.
             max_age: 0
             hosts: []
             origin_regex: false
+            forced_allow_origin_value: ~
         paths:
             '^/api/':
                 allow_origin: ['*']
@@ -76,6 +77,14 @@ allowed methods however have to be explicitly listed. `paths` must contain at le
 
 If `origin_regex` is set, `allow_origin` must be a list of regular expressions matching
 allowed origins. Remember to use `^` and `$` to clearly define the boundaries of the regex.
+
+By default, the `Access-Control-Allow-Origin` response header value is 
+the `Origin` request header value (if it matches the rules you've defined with `allow_origin`),
+so it should be fine for most of use cases. If it's not, you can override this behavior 
+by setting the exact value you want using `forced_allow_origin_value`.
+
+Be aware that even if you set `forced_allow_origin_value` to `*`, if you also set `allow_origin` to `http://example.com`,
+only this specific domain will be allowed to access your resources.
 
 > **Note:** If you allow POST methods and have 
 > [HTTP method overriding](http://symfony.com/doc/current/reference/configuration/framework.html#http-method-override)


### PR DESCRIPTION
## Why

See https://github.com/nelmio/NelmioCorsBundle/issues/66
## First commit

Feature + preflight requests tested
## Second commit

"Normal" response tested + refactoring of `CorsListener::options` attribute

=> because `$this->options` was always empty while executing `CorsListener::onKernelResponse()`... I don't think it's the case in production environment (I hope so), but at least in test environment: I just couldn't find a way to make it work the way it was done before :(
