### PR TITLE
Access-Control-Allow-Headers should not be set if the value is null.

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -114,7 +114,10 @@ class CorsListener
             $headers = $options['allow_headers'] === true
                 ? $request->headers->get('Access-Control-Request-Headers')
                 : implode(', ', $options['allow_headers']);
-            $response->headers->set('Access-Control-Allow-Headers', $headers);
+
+            if ($headers) {
+                $response->headers->set('Access-Control-Allow-Headers', $headers);
+            }
         }
         if ($options['max_age']) {
             $response->headers->set('Access-Control-Max-Age', $options['max_age']);


### PR DESCRIPTION
My scenario is that the preflight OPTIONS request is occurring on a HTTP DELETE request.

In this scenario, only the `Access-Control-Request-Method: DELETE` header is specified, and not `Access-Control-Allow-Headers`. As a result, line 117 would set this header to null value.

This PR proposes to safeguard this logic to only set this header when required.

