### PR TITLE
Decrease the listener priority

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,7 @@
         <service id="nelmio_cors.cors_listener" class="%nelmio_cors.cors_listener.class%">
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="nelmio_cors.options_resolver" />
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10000" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="250" />
         </service>
 
         <service id="nelmio_cors.options_resolver" class="%nelmio_cors.options_resolver.class%" public="false" />


### PR DESCRIPTION
In Symfony's convention, the listeners priorities are from -255 to 255, therefore a priority of 10000 is... a bit high. The main problem of not being in the conventions is that it also disallow other listeners to be the first ones, without knowing about this bundle.


I changed it to 250 so this is an extremely high value that still allows other listeners to be placed before this one (not technically but in the priority conventions).