### PR TITLE
Always load the default settings

### DIFF
--- a/DependencyInjection/NelmioCorsExtension.php
+++ b/DependencyInjection/NelmioCorsExtension.php
@@ -29,10 +29,6 @@ class NelmioCorsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (!$config['paths']) {
-            return;
-        }
-
         $defaults = array_merge(
             array(
                 'allow_origin' => array(),
@@ -57,25 +53,29 @@ class NelmioCorsExtension extends Extension
             $defaults['allow_headers'] = array_map('strtolower', $defaults['allow_headers']);
         }
         $defaults['allow_methods'] = array_map('strtoupper', $defaults['allow_methods']);
-        foreach ($config['paths'] as $path => $opts) {
-            $opts = array_filter($opts);
-            if (isset($opts['allow_origin']) && in_array('*', $opts['allow_origin'])) {
-                $opts['allow_origin'] = true;
-            }
-            if (isset($opts['allow_headers']) && in_array('*', $opts['allow_headers'])) {
-                $opts['allow_headers'] = true;
-            } elseif (isset($opts['allow_headers'])) {
-                $opts['allow_headers'] = array_map('strtolower', $opts['allow_headers']);
-            }
-            if (isset($opts['allow_methods'])) {
-                $opts['allow_methods'] = array_map('strtoupper', $opts['allow_methods']);
+
+        if ($config['paths']) {
+            foreach ($config['paths'] as $path => $opts) {
+                $opts = array_filter($opts);
+                if (isset($opts['allow_origin']) && in_array('*', $opts['allow_origin'])) {
+                    $opts['allow_origin'] = true;
+                }
+                if (isset($opts['allow_headers']) && in_array('*', $opts['allow_headers'])) {
+                    $opts['allow_headers'] = true;
+                } elseif (isset($opts['allow_headers'])) {
+                    $opts['allow_headers'] = array_map('strtolower', $opts['allow_headers']);
+                }
+                if (isset($opts['allow_methods'])) {
+                    $opts['allow_methods'] = array_map('strtoupper', $opts['allow_methods']);
+                }
+    
+                $config['paths'][$path] = $opts;
             }
 
-            $config['paths'][$path] = $opts;
+            $container->setParameter('nelmio_cors.map', $config['paths']);
         }
 
         $container->setParameter('nelmio_cors.defaults', $defaults);
-        $container->setParameter('nelmio_cors.map', $config['paths']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');


### PR DESCRIPTION
If there are no paths, the `NelmioCorsExtension::load()` method will return early:

```php
        if (!$config['paths']) {
            return;
        }
```

This effectively prevents loading the default configuration, therefore we now have to configure a workaround in our `config.yml`:

```yml
nelmio_cors:
    paths: { '^/': [] } # the NelmioCorsExtension does not load if there are no paths
```

In Contao, we dynamically provide the CORS settings, so we actually do not need to configure any paths. But we do need the `NelmioCorsExtension` class to load. 😄 

This pull request encapsulates the paths related routines in an if condition. Of course, I can also move it to a separate method if you prefer. Just let me know.