### PR TITLE
Check if origin header exists before adding it to response header

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -95,7 +95,9 @@ class CorsListener
 
         $response = $event->getResponse();
         // add CORS response headers
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        if ($request->headers->has('Origin')) {
+            $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        }
         if ($options['allow_credentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }


### PR DESCRIPTION
In some case if there are master request and sub requests, the sub request may not have the origin header and it will throw error.