### PR TITLE
feature/disableSetAccessControlAllowOrigin

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -136,6 +136,10 @@ class CorsListener
             $response->headers->set('Access-Control-Max-Age', $options['max_age']);
         }
 
+        if (0 === count($options['allow_origin'])) {
+            return $response;
+        }
+
         if (!$this->checkOrigin($request, $options)) {
             $response->headers->set('Access-Control-Allow-Origin', 'null');
 

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -216,6 +216,29 @@ class CorsListenerTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
+
+    public function testPreflightedRequestWithoutOriginDoesNotReturnOriginHeader()
+    {
+        $options = array(
+            'allow_origin' => array(),
+            'allow_methods' => array('OPTIONS', 'POST'),
+        );
+
+        // preflight
+        $req = Request::create('/foo', 'OPTIONS');
+        $req->headers->set('Origin', 'http://example.com');
+
+        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $resp = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
+        $this->assertEquals(200, $resp->getStatusCode());
+        $this->assertNull($resp->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('OPTIONS, POST', $resp->headers->get('Access-Control-Allow-Methods'));
+    }
+
     public function testRequestWithForcedAllowOriginValue()
     {
         // allow_origin matches origin header


### PR DESCRIPTION
- Added the possibility to disable having to set the header "Access-Control-Allow-Origin" by setting the option to false - allow_origin: false
- Added test testPreflightedRequestWithoutOriginDoesNotReturnOriginHeader