### PR TITLE
Make sure the preflight responses vary per Origin

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -116,6 +116,7 @@ class CorsListener
     protected function getPreflightResponse(Request $request, array $options)
     {
         $response = new Response();
+        $response->setVary(array('Origin'));
 
         if ($options['allow_credentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -73,6 +73,7 @@ class CorsListenerTest extends TestCase
         $this->assertEquals('http://example.com', $resp->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals('POST, PUT', $resp->headers->get('Access-Control-Allow-Methods'));
         $this->assertEquals('foo, bar', $resp->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(array('Origin'), $resp->getVary());
 
         // actual request
         $req = Request::create('/foo', 'POST');
@@ -120,6 +121,7 @@ class CorsListenerTest extends TestCase
         $this->assertEquals(200, $resp->getStatusCode());
         $this->assertEquals('http://example.com', $resp->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals('LINK, PUT, Link', $resp->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals(array('Origin'), $resp->getVary());
     }
 
     public function testPreflightedRequestWithForcedAllowOriginValue()
@@ -148,6 +150,7 @@ class CorsListenerTest extends TestCase
         $this->assertEquals(200, $resp->getStatusCode());
         $this->assertEquals('*', $resp->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals('GET', $resp->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals(array('Origin'), $resp->getVary());
 
         // allow_origin does not match origin header
         // => 'Access-Control-Allow-Origin' should be equal to "forced_allow_origin_value" (i.e. '*')


### PR DESCRIPTION
Hey Jordi 😄 

Just had an issue where my browser cache went crazy because the response of my API was still in the cache even though I developed locally. This is due to the missing `Vary` header on the `Origin` header.

More on that: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching