### PR TITLE
added check for runtime env vars in config

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -185,7 +185,8 @@ class CorsListener
         // check origin
         $origin = $request->headers->get('Origin');
 
-        if ($options['allow_origin'] === true) return true;
+        if ($options['allow_origin'] === true ||
+            (is_array($options['allow_origin']) && in_array('*', $options['allow_origin']))) return true;
 
         if ($options['origin_regex'] === true) {
             // origin regex matching


### PR DESCRIPTION
Firstly, I understand the CORS concept and I'm not using the origin wildcard in production, but this PR should fix some unexpected behavior.

In my experience, and perhaps I may have been approaching a problem incorrectly, Symfony's environment vars are not yet resolved when the `NelmioCorsExtension` is reached.

If I have:
```yaml
allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
```
in my config, Symfony populates this with a temp env var, not the real value but a placeholder, initially. Looks like the extension beats Symfony to parsing that value, i.e. the env var is not yet populated with its true value.

Consequently, the `NelmioCorsExtension` doesn't read the `*` that I have set in my `.env`, and skips over the following due to a negative string match, i.e. `env_XXXXXX_CORS_ALLOW_ORIGIN_XXXXX_env != '*'`:
```php
$options['allow_origin'] = true`;
```
The env var value _may_ work as expected for other values, but it's not picking up the swap `*` for `true` in the extension.

The PR does more of a runtime check against what _should be_ a boolean, and picks up where the extension lost the value.

Feel free to enlighten me, _or_ merge this PR.