### PR TITLE
Do not mutate EventDispatcher at runtime

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,9 +12,9 @@
 
     <services>
         <service id="nelmio_cors.cors_listener" class="%nelmio_cors.cors_listener.class%">
-            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="nelmio_cors.options_resolver" />
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="28" />
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="0" />
         </service>
 
         <service id="nelmio_cors.options_resolver" class="%nelmio_cors.options_resolver.class%" public="false" />

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -27,7 +27,7 @@ class CorsListenerTest extends TestCase
         m::close();
     }
 
-    public function getListener($dispatcher, array $options = array())
+    public function getListener(array $options = array())
     {
         $mergedOptions = array_merge(
             array(
@@ -47,7 +47,7 @@ class CorsListenerTest extends TestCase
         $resolver = m::mock('Nelmio\CorsBundle\Options\ResolverInterface');
         $resolver->shouldReceive('getOptions')->andReturn($mergedOptions);
 
-        return new CorsListener($dispatcher, $resolver);
+        return new CorsListener($resolver);
     }
 
     public function testPreflightedRequest()
@@ -66,7 +66,7 @@ class CorsListenerTest extends TestCase
 
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -81,18 +81,10 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Foo', 'huh');
         $req->headers->set('BAR', 'lala');
 
-        $callback = null;
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->once()
-            ->with('kernel.response', m::type('callable'), 0)
-            ->andReturnUsing(function ($cb) use (&$callback) {
-                $callback = $cb;
-            });
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
-        $this->getListener($dispatcher, $options)->onKernelResponse($event);
+        $this->getListener($options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -113,9 +105,8 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Origin', 'http://example.com');
         $req->headers->set('Access-Control-Request-Method', 'Link');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -138,13 +129,10 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Origin', 'http://example.com');
         $req->headers->set('Access-Control-Request-Method', 'GET');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
-        $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
+        $this->getListener($options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -164,13 +152,10 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Origin', 'http://example.com');
         $req->headers->set('Access-Control-Request-Method', 'GET');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
-        $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
+        $this->getListener($options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -191,10 +176,8 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Host', 'example.com');
         $req->headers->set('Origin', 'http://example.com');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
 
         $this->assertNull($event->getResponse());
     }
@@ -210,11 +193,8 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Host', 'example.com');
         $req->headers->set('Origin', 'http://evil.com');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->times(0);
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
 
         $this->assertNull($event->getResponse());
     }
@@ -232,14 +212,10 @@ class CorsListenerTest extends TestCase
         $req = Request::create('/foo', 'GET');
         $req->headers->set('Origin', 'http://example.com');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->twice()->with('kernel.response', m::type('callable'), m::type('integer'));
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
-        $this->getListener($dispatcher, $options)->onKernelResponse($event);
-        $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
+        $this->getListener($options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());
@@ -253,13 +229,10 @@ class CorsListenerTest extends TestCase
 
         $req = Request::create('/foo', 'GET');
 
-        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
-
         $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
-        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $this->getListener($options)->onKernelRequest($event);
         $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
-        $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
+        $this->getListener($options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
         $this->assertEquals(200, $resp->getStatusCode());


### PR DESCRIPTION
Hi, 

I am playing with servers that allows a kernel to handle multiple requests ([php-pm](https://github.com/php-pm/php-pm), [roadrunner](https://github.com/spiral/roadrunner)).

The current version of the CorsListener leads to memory leaks in this context (adding the same listeners on each request).

In this PR:

- `onKernelRequest` stores flags in the request attributes instead of adding listener on the dispatcher
- `onKernelResponse` is always registered and checks these flags to choose what needs to be done