### PR TITLE
Allow non-preflight OPTION requests (fixes #100)

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -70,7 +70,7 @@ class CorsListener
         }
 
         // perform preflight checks
-        if ('OPTIONS' === $request->getMethod()) {
+        if ('OPTIONS' === $request->getMethod() && $request->headers->has('Access-Control-Request-Method')) {
             $event->setResponse($this->getPreflightResponse($request, $options));
 
             return;


### PR DESCRIPTION
This MR adds a check for preflight headers when deciding whether to treat the request as a "normal" request or a preflight request according to the CORS specification.

As mentioned in issue #100 , preflight CORS `OPTIONS` requests are characterized by having an `Access-Control-Request-Method` header, which regular CORS `OPTIONS` request doesn't. Without this fix, valid CORS `OPTIONS` requests are denied because they are immediately treated as preflight requests due to simply being `OPTIONS` requests with a different `Origin` header value than the current host. This is not according to the `CORS` specification, and causes this bundle to hijack valid `OPTIONS` requests which happen to be CORS, but not preflight requests.

The solution was given in issue #100 by @LPodolski, this is just a PR to have it fixed.