### PR TITLE
Remove null 'Access-Control-Allow-Origin' if origin check has failed

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -138,7 +138,7 @@ class CorsListener
         }
 
         if (!$this->checkOrigin($request, $options)) {
-            $response->headers->set('Access-Control-Allow-Origin', 'null');
+            $response->headers->remove('Access-Control-Allow-Origin');
 
             return $response;
         }


### PR DESCRIPTION
Hey. Just a security improvement. It seems like if a request `Origin` is not allowed, `Access-Control-Allow-Origin` shouldn't be returned in a response. 

https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null