### PR TITLE
Support for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
   - COMPOSER_MEMORY_LIMIT=-1 composer update
 
 script: |
-  SYMFONY_DEPRECATIONS_HELPER=max[direct]=0 SYMFONY_PHPUNIT_VERSION=7.5 ./vendor/bin/simple-phpunit
+  ./vendor/bin/simple-phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
 
 sudo: false
 
@@ -14,8 +10,4 @@ before_install:
   - COMPOSER_MEMORY_LIMIT=-1 composer update
 
 script: |
-  if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then
-      SYMFONY_PHPUNIT_VERSION=6.4 ./vendor/bin/simple-phpunit
-  else
-      ./vendor/bin/simple-phpunit
-  fi
+  SYMFONY_PHPUNIT_VERSION=8.3 ./vendor/bin/simple-phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.1
   - 7.2
   - 7.3
 
@@ -10,4 +11,4 @@ before_install:
   - COMPOSER_MEMORY_LIMIT=-1 composer update
 
 script: |
-  SYMFONY_PHPUNIT_VERSION=8.3 ./vendor/bin/simple-phpunit
+  SYMFONY_DEPRECATIONS_HELPER=max[direct]=0 SYMFONY_PHPUNIT_VERSION=7.5 ./vendor/bin/simple-phpunit

--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -11,13 +11,13 @@
 
 namespace Nelmio\CorsBundle\EventListener;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Nelmio\CorsBundle\Options\ResolverInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Nelmio\CorsBundle\Options\ResolverInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Adds CORS headers and handles pre-flight requests
@@ -47,7 +47,7 @@ class CorsListener
         $this->configurationResolver = $configurationResolver;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -83,7 +83,7 @@ class CorsListener
         $this->dispatcher->addListener('kernel.response', array($this, 'onKernelResponse'), 0);
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -104,7 +104,7 @@ class CorsListener
         }
     }
 
-    public function forceAccessControlAllowOriginHeader(FilterResponseEvent $event)
+    public function forceAccessControlAllowOriginHeader(ResponseEvent $event)
     {
         if (!$options = $this->configurationResolver->getOptions($request = $event->getRequest())) {
             return;

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -11,18 +11,18 @@
 
 namespace Nelmio\CorsBundle\Tests;
 
+use Mockery as m;
 use Nelmio\CorsBundle\EventListener\CorsListener;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class CorsListenerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -65,7 +65,7 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Access-Control-Request-Headers', 'Foo, BAR');
 
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
@@ -89,9 +89,9 @@ class CorsListenerTest extends TestCase
                 $callback = $cb;
             });
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
-        $event = new FilterResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
+        $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
         $this->getListener($dispatcher, $options)->onKernelResponse($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
@@ -114,7 +114,7 @@ class CorsListenerTest extends TestCase
         $req->headers->set('Access-Control-Request-Method', 'Link');
 
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
@@ -141,9 +141,9 @@ class CorsListenerTest extends TestCase
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
-        $event = new FilterResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
+        $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
         $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
@@ -167,9 +167,9 @@ class CorsListenerTest extends TestCase
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
-        $event = new FilterResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
+        $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, $event->getResponse());
         $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
@@ -193,7 +193,7 @@ class CorsListenerTest extends TestCase
 
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
 
         $this->assertNull($event->getResponse());
@@ -213,7 +213,7 @@ class CorsListenerTest extends TestCase
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->shouldReceive('addListener')->times(0);
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
 
         $this->assertNull($event->getResponse());
@@ -235,9 +235,9 @@ class CorsListenerTest extends TestCase
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->shouldReceive('addListener')->twice()->with('kernel.response', m::type('callable'), m::type('integer'));
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
-        $event = new FilterResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
+        $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
         $this->getListener($dispatcher, $options)->onKernelResponse($event);
         $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
         $resp = $event->getResponse();
@@ -256,9 +256,9 @@ class CorsListenerTest extends TestCase
         $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->shouldReceive('addListener')->once()->with('kernel.response', m::type('callable'), -1);
 
-        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
         $this->getListener($dispatcher, $options)->onKernelRequest($event);
-        $event = new FilterResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
+        $event = new ResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST, new Response());
         $this->getListener($dispatcher, $options)->forceAccessControlAllowOriginHeader($event);
         $resp = $event->getResponse();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);

--- a/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
+++ b/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
@@ -9,51 +9,45 @@
  */
 namespace Nelmio\Tests\DependencyInjection;
 
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Fixtures\ProviderMock;
+use Nelmio\CorsBundle\DependencyInjection\Compiler\CorsConfigurationProviderPass;
+use Nelmio\CorsBundle\DependencyInjection\NelmioCorsExtension;
+use Nelmio\CorsBundle\Options\ConfigProvider;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Nelmio\CorsBundle\DependencyInjection\Compiler\CorsConfigurationProviderPass;
-use Symfony\Component\DependencyInjection\Reference;
 
-class CorsConfigurationProviderPassTest extends AbstractCompilerPassTestCase
+class CorsConfigurationProviderPassTest extends TestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container): void
-    {
-        $container->addCompilerPass(new CorsConfigurationProviderPass());
-    }
-
     public function testCollectProviders()
     {
-        $configurationResolver = new Definition();
-        $this->setDefinition('nelmio_cors.options_resolver', $configurationResolver);
+        $container = $this->getContainerBuilder();
+        $container->compile();
 
-        $configurationProvider = new Definition();
-        $configurationProvider->addTag('nelmio_cors.options_provider');
-        $this->setDefinition('cors.options_provider.test1', $configurationProvider);
+        $arguments = $container->getDefinition('nelmio_cors.options_resolver')->getArguments();
 
-        $configurationProvider = new Definition();
-        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 10));
-        $this->setDefinition('cors.options_provider.test2', $configurationProvider);
+        static::assertCount(4, $arguments[0] ?? []);
+        static::assertSame(ConfigProvider::class, (string) $arguments[0][0]->getClass());
+        static::assertSame('cors.options_provider.test3', (string) $arguments[0][1]);
+        static::assertSame('cors.options_provider.test4', (string) $arguments[0][2]);
+        static::assertSame('cors.options_provider.test2', (string) $arguments[0][3]);
+    }
 
-        $configurationProvider = new Definition();
-        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 5));
-        $this->setDefinition('cors.options_provider.test3', $configurationProvider);
+    protected function getContainerBuilder(): ContainerBuilder
+    {
+        $extension = new NelmioCorsExtension();
+        $container = new ContainerBuilder();
+        $optionProviders = [
+            'cors.options_provider.test1' => (new Definition(ProviderMock::class))->setPublic(true),
+            'cors.options_provider.test2' => (new Definition(ProviderMock::class))->setPublic(true)->addTag('nelmio_cors.options_provider', ['priority' => 10]),
+            'cors.options_provider.test3' => (new Definition(ProviderMock::class))->setPublic(true)->addTag('nelmio_cors.options_provider', ['priority' => 5]),
+            'cors.options_provider.test4' => (new Definition(ProviderMock::class))->setPublic(true)->addTag('nelmio_cors.options_provider', ['priority' => 5]),
+        ];
+        $container->addDefinitions($optionProviders);
+        $container->addCompilerPass(new CorsConfigurationProviderPass());
+        $extension->load([], $container);
+        $container->getDefinition('nelmio_cors.options_resolver')->setPublic(true);
 
-        $configurationProvider = new Definition();
-        $configurationProvider->addTag('nelmio_cors.options_provider', array('priority' => 5));
-        $this->setDefinition('cors.options_provider.test4', $configurationProvider);
-
-        $this->compile();
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'nelmio_cors.options_resolver',
-            0,
-            array(
-                new Reference('cors.options_provider.test1'),
-                new Reference('cors.options_provider.test3'),
-                new Reference('cors.options_provider.test4'),
-                new Reference('cors.options_provider.test2')
-            )
-        );
+        return $container;
     }
 }

--- a/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
+++ b/Tests/DependencyInjection/CorsConfigurationProviderPassTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CorsConfigurationProviderPassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new CorsConfigurationProviderPass());
     }

--- a/Tests/Fixtures/ProviderMock.php
+++ b/Tests/Fixtures/ProviderMock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Nelmio\CorsBundle\Options\ProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ProviderMock implements ProviderInterface
+{
+    public function __construct() {}
+
+    public function getOptions(Request $request) {}
+}

--- a/Tests/Options/ResolverTest.php
+++ b/Tests/Options/ResolverTest.php
@@ -38,7 +38,7 @@ class ResolverTest extends TestCase
      */
     protected $extraProviderValue;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "^4.0 || ^5.0"
+        "symfony/framework-bundle": "^4.3 || ^5.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "mockery/mockery": "^1.2",
-        "symfony/phpunit-bridge": "^4.0 || ^5.0"
+        "symfony/phpunit-bridge": "^4.3 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Nelmio\\CorsBundle\\": "" },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "symfony/framework-bundle": "^4.3 || ^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "mockery/mockery": "^1.2",
         "symfony/phpunit-bridge": "^4.3 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "nelmio/cors-bundle",
-    "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Symfony2 application",
+    "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Symfony application",
     "keywords": ["cors", "crossdomain", "api"],
     "type": "symfony-bundle",
     "license": "MIT",
@@ -15,12 +15,12 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0"
+        "symfony/framework-bundle": "^4.0 || ^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0 || ^2.0",
-        "mockery/mockery": "^0.9 || ^1.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "mockery/mockery": "^1.2",
+        "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Nelmio\\CorsBundle\\": "" },
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "Tests/bootstrap.php">
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,13 @@
     stopOnFailure               = "false"
     bootstrap                   = "Tests/bootstrap.php">
 
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+    </php>
+
     <testsuites>
         <testsuite name="NelmioCorsBundle Test Suite">
             <directory>Tests</directory>


### PR DESCRIPTION
This is probably going to need a few changes based on feedback. I just thought I'd get it all together & testable first.

~There are two related upstream PRs for SymfonyTest https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/pull/121 and https://github.com/SymfonyTest/SymfonyConfigTest/pull/63 to make the DI test package work.~

~That is where part of the version bump(s) come in. The package has a BC break in signatures after v3, and v4 requires PHPUnit 8 for `TestCase` compatibility.~

So please let me know what more is wanted, or not, and I'll happily work to get this over the line :smiley_cat: 

Summary
-------

- Drop PHP < 7.1 ~7.2~
- Drop Symfony < 4.3 ~4.0~
- Deprecations for HttpKernel Events
- Drop matthiasnoback/symfony-dependency-injection-test
- ~Update Travis to use PHPUnit 8.3~
- Remove `syntaxCheck` from `phpunit.xml`
- Signature updates
