### PR TITLE
[RFC] Include `Origin` as `Vary`  header for cacheable responses

### DIFF
--- a/EventListener/CacheableResponseVaryListener.php
+++ b/EventListener/CacheableResponseVaryListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Nelmio\CorsBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * When a response is cacheable the `Vary` header has to include `Origin`.
+ */
+final class CacheableResponseVaryListener
+{
+    public function onResponse(ResponseEvent $event)
+    {
+        $response = $event->getResponse();
+
+        if (!$response->isCacheable()) {
+            return;
+        }
+
+        if (!\in_array('Origin', $response->getVary(), true)) {
+            $response->setVary(array_merge(['Origin'], $response->getVary()));
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,5 +24,9 @@
             <argument>%nelmio_cors.defaults%</argument>
             <tag name="nelmio_cors.options_provider" priority="-1" />
         </service>
+
+        <service id="nelmio_cors.cacheable_response_vary_listener" class="Nelmio\CorsBundle\EventListener\CacheableResponseVaryListener">
+            <tag name="kernel.event_listener" event="kernel.response" method="onResponse" />
+        </service>
     </services>
 </container>

--- a/Tests/EventListener/CacheableResponseVaryListenerTest.php
+++ b/Tests/EventListener/CacheableResponseVaryListenerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Nelmio\Tests\EventListener;
+
+use Nelmio\CorsBundle\EventListener\CacheableResponseVaryListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class CacheableResponseVaryListenerTest extends TestCase
+{
+    private $listener;
+    private $event;
+    private $response;
+
+    protected function setUp(): void
+    {
+        $this->event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            $this->response = new Response()
+        );
+        $this->listener = new CacheableResponseVaryListener();
+    }
+
+    public function testOriginIsAddedAsVaryHeaderOnCacheableResponse()
+    {
+        $this->response->setTtl(300);
+        $this->listener->onResponse($this->event);
+
+        self::assertContains('Origin', $this->event->getResponse()->headers->get('Vary'));
+    }
+
+    public function testOriginIsNotAddedAsVaryHeaderOnNonCacheableResponse()
+    {
+        $this->listener->onResponse($this->event);
+
+        self::assertNull($this->event->getResponse()->headers->get('Vary'));
+    }
+}


### PR DESCRIPTION
fixes #123 

For cacheable responses the `Vary` header should include `Origin` to let caching proxies respect the request's origin.