### PR TITLE
Sanitize response message for unathorized headers

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -176,8 +176,9 @@ class CorsListener
                     continue;
                 }
                 if (!in_array($header, $options['allow_headers'], true)) {
+                    $sanitizedMessage = htmlentities('Unauthorized header '.$header, ENT_QUOTES, 'UTF-8');
                     $response->setStatusCode(400);
-                    $response->setContent('Unauthorized header '.$header);
+                    $response->setContent($sanitizedMessage);
                     break;
                 }
             }


### PR DESCRIPTION
### Summary

This pull request adds sanitation to the response body when unauthorized headers are added to the request payload. The reason for doing so is to prevent cross-side scripting vulnerabilities.

Resolves #162