### PR TITLE
Fix Fixtures\ProviderMock interface violation

### DIFF
--- a/Tests/Fixtures/ProviderMock.php
+++ b/Tests/Fixtures/ProviderMock.php
@@ -11,5 +11,5 @@ final class ProviderMock implements ProviderInterface
 {
     public function __construct() {}
 
-    public function getOptions(Request $request): void {}
+    public function getOptions(Request $request): array {}
 }


### PR DESCRIPTION
**Fixes:**

```
bin/console hautelook:fixtures:load
Careful, database will be purged. Do you want to continue y/N ?y

Fatal error: Declaration of Fixtures\ProviderMock::getOptions(Symfony\Component\HttpFoundation\Request $request): void must be compatible with Nelmio\CorsBundle\Options\ProviderInterface::getOptions(Symfony\Component\HttpFoundation\Request $request): array in /var/www/html/vendor/nelmio/cors-bundle/tests/fixtures/ProviderMock.php on line 14
09:12:27 CRITICAL  [php] Fatal Compile Error: Declaration of Fixtures\ProviderMock::getOptions(Symfony\Component\HttpFoundation\Request $request): void must be compatible with Nelmio\CorsBundle\Options\ProviderInterface::getOptions(Symfony\Component\HttpFoundation\Request $request): array ["exception" => Symfony\Component\ErrorHandler\Error\FatalError^ { …}]

In ProviderMock.php line 14:

  Compile Error: Declaration of Fixtures\ProviderMock::getOptions(Symfony\Component\HttpFoundation\Request $request): void must be compatible with Nelmio\CorsBundle\Opt
  ions\ProviderInterface::getOptions(Symfony\Component\HttpFoundation\Request $request): array


hautelook:fixtures:load [-b|--bundle [BUNDLE]] [--no-bundles [NO-BUNDLES]] [-m|--manager MANAGER] [--append] [--shard SHARD] [--purge-with-truncate]
```
Basically `Fixtures\ProviderMock` wasn't implementing the `ProviderInterface` correctly and for some reason this broke one of my projects I'm currently migrating to PHP 8 & symfony 5.3. The symfony compiler all of a sudden chokes on it when running some unrelated console command.