### PR TITLE
Add configuration flag to allow to opt-out from skipping CORS when same as origin

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ class Configuration implements ConfigurationInterface
                     ->append($this->getHosts())
                     ->append($this->getOriginRegex())
                     ->append($this->getForcedAllowOriginValue())
+                    ->append($this->getSkipSameAsOrigin())
                 ->end()
 
                 ->arrayNode('paths')
@@ -64,11 +65,20 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getHosts())
                         ->append($this->getOriginRegex())
                         ->append($this->getForcedAllowOriginValue())
+                        ->append($this->getSkipSameAsOrigin())
                     ->end()
                 ->end()
             ;
 
         return $treeBuilder;
+    }
+
+    private function getSkipSameAsOrigin(): BooleanNodeDefinition
+    {
+        $node = new BooleanNodeDefinition('skip_same_as_origin');
+        $node->defaultTrue();
+
+        return $node;
     }
 
     private function getAllowCredentials(): BooleanNodeDefinition

--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -68,7 +68,7 @@ class CorsListener
             return;
         }
 
-        if (true !== $options['skip_same_as_origin'] && $request->headers->get('Origin') === $request->getSchemeAndHttpHost()) {
+        if ($options['skip_same_as_origin'] && $request->headers->get('Origin') === $request->getSchemeAndHttpHost()) {
             return;
         }
 

--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -64,7 +64,11 @@ class CorsListener
         }
 
         // skip if not a CORS request
-        if (!$request->headers->has('Origin') || $request->headers->get('Origin') === $request->getSchemeAndHttpHost()) {
+        if (!$request->headers->has('Origin')) {
+            return;
+        }
+
+        if (true !== $options['skip_same_as_origin'] && $request->headers->get('Origin') === $request->getSchemeAndHttpHost()) {
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ seconds.
             hosts: []
             origin_regex: false
             forced_allow_origin_value: ~
+            skip_same_as_origin: true
         paths:
             '^/api/':
                 allow_origin: ['*']


### PR DESCRIPTION
I would like to propose introducing a flag that allows the bundle user to opt-out of the default "skip if same as origin" logic done in `CorsListener` (see https://github.com/nelmio/NelmioCorsBundle/blob/master/EventListener/CorsListener.php#L67).

As far as I understand allowing this would not violate the CORS spec.

For us this is a valid usage scenario, for reasons which are a bit convoluted to explain, but in short we have a reverse proxy setup where the symfony backend is not aware of all the domains it can be routed through. In this scenario, we are in fact using an `Origin` header which matches (even though the external facing domain does not) the same scheme & http host the symfony backend "sees".

With this proposed change nothing would change for current users, while allowing the flexibility for those that want to opt-out to do so without having to override the whole `onKernelRequest` method from the original listener.

Any feedback or help refining this is welcomed.