### PR TITLE
Changed the priority of the CacheableResponseVaryListener

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,7 +26,7 @@
         </service>
 
         <service id="nelmio_cors.cacheable_response_vary_listener" class="Nelmio\CorsBundle\EventListener\CacheableResponseVaryListener">
-            <tag name="kernel.event_listener" event="kernel.response" method="onResponse" />
+            <tag name="kernel.event_listener" event="kernel.response" method="onResponse" priority="-10" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Changed the priority of the CacheableResponseVaryListener so that it runs after the cache headers have been added by the FrameworkExtraBundle

After thinking more about what I wrote in #171, I think it makes sense for this listener to have a lower priority by default.