### PR TITLE
[Doc] Fixed a minor syntax issue

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -32,7 +32,7 @@ the ``config/bundles.php`` file of your project::
 
 If you don't have a ``config/bundles.php`` file in your project, chances are that
 you're using an older Symfony version. In this case, you should have an
-``app/AppKernel.php`` file instead. Edit such file:
+``app/AppKernel.php`` file instead. Edit such file::
 
     <?php
     // app/AppKernel.php


### PR DESCRIPTION
The docs of this bundle are now online: https://symfony.com/bundles/NelmioCorsBundle/current/index.html

I spotted a minor syntax issue and this PR fixes it. Thanks!

A note for people not used to RST syntax. Code blocks are usually defined like this:

```rst
.. code-block:: php

    // ...
```

However, since PHP examples are so common in Symfony Docs, we use a trick which consists of this:

```rst
Any normal text here, like a paragraph::

    // ... PHP code here

More normal text here [...]
```

The two `::` at the end of any text means that the following indented content is a PHP code block.