### PR TITLE
Remove default values for boolean nodes in paths config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,16 +40,16 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('defaults')
                     ->addDefaultsIfNotSet()
-                    ->append($this->getAllowCredentials())
+                    ->append($this->getAllowCredentials(true))
                     ->append($this->getAllowOrigin())
                     ->append($this->getAllowHeaders())
                     ->append($this->getAllowMethods())
                     ->append($this->getExposeHeaders())
                     ->append($this->getMaxAge())
                     ->append($this->getHosts())
-                    ->append($this->getOriginRegex())
+                    ->append($this->getOriginRegex(true))
                     ->append($this->getForcedAllowOriginValue())
-                    ->append($this->getSkipSameAsOrigin())
+                    ->append($this->getSkipSameAsOrigin(true))
                 ->end()
 
                 ->arrayNode('paths')
@@ -73,18 +73,24 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    private function getSkipSameAsOrigin(): BooleanNodeDefinition
+    private function getSkipSameAsOrigin(bool $withDefaultValue = false): BooleanNodeDefinition
     {
         $node = new BooleanNodeDefinition('skip_same_as_origin');
-        $node->defaultTrue();
+
+        if ($withDefaultValue) {
+            $node->defaultTrue();
+        }
 
         return $node;
     }
 
-    private function getAllowCredentials(): BooleanNodeDefinition
+    private function getAllowCredentials(bool $withDefaultValue = false): BooleanNodeDefinition
     {
         $node = new BooleanNodeDefinition('allow_credentials');
-        $node->defaultFalse();
+
+        if ($withDefaultValue) {
+            $node->defaultFalse();
+        }
 
         return $node;
     }
@@ -182,10 +188,13 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function getOriginRegex(): BooleanNodeDefinition
+    private function getOriginRegex(bool $withDefaultValue = false): BooleanNodeDefinition
     {
         $node = new BooleanNodeDefinition('origin_regex');
-        $node->defaultFalse();
+
+        if ($withDefaultValue) {
+            $node->defaultFalse();
+        }
 
         return $node;
     }


### PR DESCRIPTION
If we set a default value for the boolean nodes `paths` config, it always overrides the default value in the `defaults` section.

Imagine that we have the following config:
```yaml
nelmio_cors:
    defaults:
        skip_same_as_origin: false
    paths:
        '^/':
            origin_regex: true
            allow_origin: ['^http://localhost:[0-9]+']
```

As a result, we will have `skip_same_as_origin = true` for the `^/` path. This is not expected behaviour.
            