### PR TITLE
fix: correct interpretation of environment variables

### DIFF
--- a/DependencyInjection/NelmioCorsExtension.php
+++ b/DependencyInjection/NelmioCorsExtension.php
@@ -42,10 +42,12 @@ class NelmioCorsExtension extends Extension
             ],
             $config['defaults']
         );
-
+       
         if ($defaults['allow_credentials'] && in_array('*', $defaults['expose_headers'], true)) {
             throw new \UnexpectedValueException('nelmio_cors expose_headers cannot contain a wildcard (*) when allow_credentials is enabled.');
         }
+
+        $isResolvedOpt = fn(mixed $opt): bool => $container->resolveEnvPlaceholders($opt) != $opt;
 
         // normalize array('*') to true
         if (in_array('*', $defaults['allow_origin'])) {
@@ -54,9 +56,9 @@ class NelmioCorsExtension extends Extension
         if (in_array('*', $defaults['allow_headers'])) {
             $defaults['allow_headers'] = true;
         } else {
-            $defaults['allow_headers'] = array_map('strtolower', $defaults['allow_headers']);
+            $defaults['allow_headers'] = array_map(fn($opt) => $isResolvedOpt($opt) ? $opt : strtolower($opt), $defaults['allow_headers']);
         }
-        $defaults['allow_methods'] = array_map('strtoupper', $defaults['allow_methods']);
+        $defaults['allow_methods'] = array_map(fn($opt) => $isResolvedOpt($opt) ? $opt : strtoupper($opt), $defaults['allow_methods']);
 
         if ($config['paths']) {
             foreach ($config['paths'] as $path => $opts) {
@@ -67,10 +69,10 @@ class NelmioCorsExtension extends Extension
                 if (isset($opts['allow_headers']) && in_array('*', $opts['allow_headers'])) {
                     $opts['allow_headers'] = true;
                 } elseif (isset($opts['allow_headers'])) {
-                    $opts['allow_headers'] = array_map('strtolower', $opts['allow_headers']);
+                    $opts['allow_headers'] = array_map(fn($opt) => $isResolvedOpt($opt) ? $opt : strtolower($opt), $opts['allow_headers']);
                 }
                 if (isset($opts['allow_methods'])) {
-                    $opts['allow_methods'] = array_map('strtoupper', $opts['allow_methods']);
+                    $opts['allow_methods'] = array_map(fn($opt) => $isResolvedOpt($opt) ? $opt : strtoupper($opt), $opts['allow_methods']);
                 }
 
                 $config['paths'][$path] = $opts;


### PR DESCRIPTION
There is a problem with the interpretation of environment variables in the current system.

When we want to add an environment variable in the configuration file currently like this:

```yaml   paths:
        '^/v1/':
            allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
            allow_headers: ['%env(CORS_ALLOW_HEADERS)%']
            allow_methods: ['%env(CORS_ALLOW_METHOD_ONE)%', '%env(CORS_ALLOW_METHOD_TWO)%']
```

Only the "allow_origin" key works because there is no processing done behind the user's back.

On the other keys, a treatment is applied (putting everything in upper or lower case).

Only when you want to add an environment variable, this is automatically managed by Symfony in the form of a hash.

However, when these modifications are made to our values (which are actually environment variable keys) this modifies the key and Symfony no longer finds the associated value.

For example, our "**%env(CORS_ALLOW_HEADERS)%**" key becomes "**env_588d27cb6d976748_string_CORS_ALLOW_ORIGIN_717607a427d05ca1694bd72e43dce0ea**" at the time of interpretation by Symfony, but is later transformed by the bundle into "**env_588d27cb6d976748_string_cors_allow_origin_717607a427d05ca1694bd72e43dce0ea**" (all lowercase). And the Symfony, no longer knows how to return the value of this key.

The idea to resolve the problem and to be able to use environment variables everywhere, is to test if they can be solved with the "resolveEnvPlaceholders" function of Symfony. If so, we leave as is, otherwise we add the filter.