### PR TITLE
feat: fix deprecation for Extension

### DIFF
--- a/DependencyInjection/NelmioCorsExtension.php
+++ b/DependencyInjection/NelmioCorsExtension.php
@@ -13,8 +13,8 @@ namespace Nelmio\CorsBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>


### PR DESCRIPTION
`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Nelmio\CorsBundle\DependencyInjection\NelmioCorsExtension".`